### PR TITLE
Runner now supports embedded test suites in build_suite() result.

### DIFF
--- a/cricket/django/discoverer.py
+++ b/cricket/django/discoverer.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import
 
+from unittest import TestSuite
+
 from django.conf import settings
 from django.test.simple import DjangoTestSuiteRunner
 from django.test.utils import get_runner
@@ -14,16 +16,22 @@ class TestDiscoverer(TestRunnerClass):
     Doesn't actually run any of the tests.
     """
     def run_tests(self, test_labels, extra_tests=None, **kwargs):
-        for test in self.build_suite(test_labels):
-            # Django 1.6 introduce the new-style test runner.
-            # If that test runner is in use, we use the full test name.
-            # If we're still using a pre 1.6-style runner, we need to
-            # drop out all everything between the app name and the test module.
-            if issubclass(TestRunnerClass, DjangoTestSuiteRunner):
-                parts = test.id().split('.')
-                tests_index = parts.index('tests')
-                print '%s.%s.%s' % (parts[tests_index - 1], parts[-2], parts[-1])
-            else:
-                print test.id()
+        def walk_suite(suite):
+            for test in suite:
+                if isinstance(test, TestSuite):
+                    walk_suite(test)
+                    continue
+                # Django 1.6 introduce the new-style test runner.
+                # If that test runner is in use, we use the full test name.
+                # If we're still using a pre 1.6-style runner, we need to
+                # drop out all everything between the app name and the test module.
+                if issubclass(TestRunnerClass, DjangoTestSuiteRunner):
+                    parts = test.id().split('.')
+                    tests_index = parts.index('tests')
+                    print '%s.%s.%s' % (parts[tests_index - 1], parts[-2], parts[-1])
+                else:
+                   print test.id()
+
+        walk_suite(self.build_suite(test_labels))
 
         return 0


### PR DESCRIPTION
There was a problem, where Django test discoverer threw an exception while trying to process <i>TestSuites</i> embedded in <i>build_suite()'s</i> output:

```
File "C:\Coding\Soft\Envs\kinder\Lib\site-packages\django\core\management\base.py", line 232, in execute
output = self.handle(*args, **options)
File "C:\Coding\Soft\Envs\kinder\Lib\site-packages\south\management\commands\test.py", line 8, in handle
super(Command, self).handle(*args, **kwargs)
File "C:\Coding\Soft\Envs\kinder\Lib\site-packages\django\core\management\commands\test.py", line 72, in handle
failures = test_runner.run_tests(test_labels)
File "C:\Coding\Soft\Envs\kinder\Lib\site-packages\cricket\django\discoverer.py", line 25, in run_tests
parts = test.id().split('.')
AttributeError: 'TestSuite' object has no attribute 'id'
```

 Although you can always click "Continue" and ignore this exceptions, it hides embedded test suites from discovery and may prevent cricket from finding special test instances (e.g. doctests). 

Included changeset treats <i>build_suite()</i> output as a trivial list of leafs and nodes, with nodes being additional test suites, which in turn can include other suites etc.
