### PR TITLE
Issue #24: fixes for running under cricket under Python < 2.7

### DIFF
--- a/cricket/pipes.py
+++ b/cricket/pipes.py
@@ -5,7 +5,11 @@ from StringIO import StringIO
 import sys
 import time
 import traceback
-import unittest
+
+if sys.version_info < (2, 7):
+    import unittest2 as unittest
+else:
+    import unittest
 
 
 def trim_docstring(docstring):

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ required_pkgs = [
     'tkreadonly',
 ]
 if sys.version_info < (2, 7):
-    required_pkgs.append('argparse')
+    required_pkgs.extend(['argparse', 'unittest2', 'pyttk'])
 
 setup(
     name='cricket',


### PR DESCRIPTION
_ttk_ was added to standard Python distribution in 2.7, so it wil fail under earlier versions:
http://bugs.python.org/issue2983

To mitigate this, we check for installed Python's version and add _pyttk_ if necessary.

We use _unittest2_ in place of unittest because it contains backported changes from _unittest_ in Python 2.7 and cricket relies on them.
