### PR TITLE
Add support for Django 1.8+

### DIFF
--- a/cricket/django/discoverer.py
+++ b/cricket/django/discoverer.py
@@ -3,7 +3,10 @@ from __future__ import absolute_import
 import unittest
 
 from django.conf import settings
-from django.test.simple import DjangoTestSuiteRunner
+try:
+    from django.test.simple import DjangoTestSuiteRunner
+except ImportError:  # django.test.simple was removed in Django 1.8
+    DjangoTestSuiteRunner = None
 from django.test.utils import get_runner
 
 # Dynamically retrieve the test runner class for this project.
@@ -23,7 +26,8 @@ class TestDiscoverer(TestRunnerClass):
             # drop out all everything between the app name and the test module.
             if isinstance(test, unittest.TestSuite):
                 self._output_suite(test)
-            elif issubclass(TestRunnerClass, DjangoTestSuiteRunner):
+            elif (DjangoTestSuiteRunner and
+                  issubclass(TestRunnerClass, DjangoTestSuiteRunner)):
                 parts = test.id().split('.')
                 tests_index = parts.index('tests')
                 print '%s.%s.%s' % (parts[tests_index - 1], parts[-2], parts[-1])


### PR DESCRIPTION
Following 1.6 deprecation `django.test.simple` was removed from the master branch by django/django@bf5430a20b65b3e76a2f8cd2580101e0baa59f82.
