### PR TITLE
Add support for unit test discovery

### DIFF
--- a/cricket/unittest/discoverer.py
+++ b/cricket/unittest/discoverer.py
@@ -25,37 +25,41 @@ def consume(iterable):
         except:
             yield item
 
+
 class PyTestDiscoverer:
 
-    def __init__(self):
-
+    def __init__(self, start='.', pattern='test*.py', top=None):
+        self.start = start
+        self.pattern = pattern
+        self.top = top
         self.collected_tests = []
-
 
     def __str__(self):
         '''
         Builds the dotted namespace expected by cricket
         '''
-
         resultstr = '\n'.join(self.collected_tests)
-
         return resultstr.strip()
-
 
     def collect_tests(self):
         '''
         Collect a list of potentially runnable tests
         '''
-        
         loader = unittest.TestLoader()
-        suite = loader.discover('.')
+        suite = loader.discover(self.start, self.pattern, self.top)
         flatresults = list(consume(suite))
         named = [r.id() for r in flatresults]
         self.collected_tests = named
 
-            
-if __name__ == '__main__':
 
-    PTD = PyTestDiscoverer()
+if __name__ == '__main__':
+    from argparse import ArgumentParser
+    from cricket.unittest.options import add_arguments
+
+    parser = ArgumentParser()
+    add_arguments(parser)
+    options = parser.parse_args()
+
+    PTD = PyTestDiscoverer(options.start, options.pattern, options.top)
     PTD.collect_tests()
     print str(PTD)

--- a/cricket/unittest/model.py
+++ b/cricket/unittest/model.py
@@ -1,19 +1,38 @@
 import sys
 
 from cricket.model import Project
+import cricket.unittest.options
+
 
 class UnittestProject(Project):
 
     def __init__(self, options=None):
+        self.start = getattr(options, 'start', '.')
+        self.pattern = getattr(options, 'pattern', 'test*py')
+        self.top = getattr(options, 'top', None)
         super(UnittestProject, self).__init__()
+
+    @classmethod
+    def add_arguments(cls, parser):
+        cricket.unittest.options.add_arguments(parser)
 
     def discover_commandline(self):
         "Command line: Discover all available tests in a project."
-        return [sys.executable, '-m', 'cricket.unittest.discoverer']
+        args = [sys.executable, '-m', 'cricket.unittest.discoverer',
+                self.start, self.pattern]
+        if self.top is not None:
+            args.append(self.top)
+        return args
 
     def execute_commandline(self, labels):
         "Return the command line to execute the specified test labels"
         args = [sys.executable, '-m', 'cricket.unittest.executor']
         if self.coverage:
             args.append('--coverage')
-        return args + labels
+        if labels:
+            args.extend(['-t'] + labels)
+        else:
+            args.extend([self.start, self.pattern])
+            if self.top is not None:
+                args.append(self.top)
+        return args

--- a/cricket/unittest/options.py
+++ b/cricket/unittest/options.py
@@ -1,0 +1,15 @@
+"""
+argparse options common to discoverer, executor and model.
+"""
+
+
+def add_arguments(parser):
+    """
+    Add unittest discovery settings to the argument parser.
+    """
+    parser.add_argument('start', nargs='?', default='.',
+        help="Directory to start discovery ('.' default)")
+    parser.add_argument('pattern', nargs='?', default='test*.py',
+        help="Pattern to match tests ('test*.py' default)")
+    parser.add_argument('top', nargs='?', default=None,
+        help='Top level directory of project (defaults to start directory)')

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -51,6 +51,18 @@ In a unittest project, install cricket, and then run it::
 This will pop up a GUI window. Hit "Run all", and watch your test suite
 execute.
 
+``cricket-unittest`` also accepts the 'discover' arguments for ``unittest``::
+
+    usage: cricket-unittest [-h] [--version] [start] [pattern] [top]
+
+(See also ``cricket-unittest -h``.)
+
+For example this will find tests inside packages.  For example, if you have
+``simplejson`` installed, you can run the tests present in
+``simplejson.tests``::
+
+    $ cricket-unittest simplejson
+
 Problems under Ubuntu
 ~~~~~~~~~~~~~~~~~~~~~
 

--- a/tests/test_unit_integration.py
+++ b/tests/test_unit_integration.py
@@ -33,7 +33,7 @@ class TestExecutorCmdLine(unittest.TestCase):
         '''
 
         labels = ['tests.test_unit_integration.TestCollection']
-        cmdline = ['python', '-m', 'cricket.unittest.executor'] + labels
+        cmdline = ['python', '-m', 'cricket.unittest.executor', '-t'] + labels
 
         runner = subprocess.Popen(
             cmdline,


### PR DESCRIPTION
See #27.  The original behaviour is preserved.

Its a bit messy around the executor which needs to accept either discovery arguments or a list of test names.
