### PR TITLE
fixed typo

### DIFF
--- a/cricket/view.py
+++ b/cricket/view.py
@@ -11,7 +11,7 @@ import webbrowser
 import toga
 from toga.style import Pack
 from toga.style.pack import RIGHT, LEFT, CENTER, ROW, COLUMN, VISIBLE, HIDDEN
-from toga.font import BOLD, SANS_SERIF
+from toga.fonts import BOLD, SANS_SERIF
 
 # Check for the existence of coverage and duvet
 try:

--- a/cricket/view.py
+++ b/cricket/view.py
@@ -10,7 +10,7 @@ import webbrowser
 
 import toga
 from toga.style import Pack
-from toga.style.pack import RIGHT, LEFT, CENTER, ROW, COLUMN, VISIBLE, HIDDEN
+from toga.style.pack import RIGHT, CENTER, ROW, COLUMN
 from toga.fonts import BOLD, SANS_SERIF
 
 # Check for the existence of coverage and duvet


### PR DESCRIPTION
Hey, after installing your package on latest commit it resulted in an import error while running `cricket-pytest` command:
`Traceback (most recent call last):
  File "/Users/yinon.horev/code/csr_vnv/.venv/bin/cricket-pytest", line 5, in <module>
    from cricket.pytest.__main__ import run
  File "/Users/yinon.horev/code/csr_vnv/.venv/lib/python3.7/site-packages/cricket/pytest/__main__.py", line 4, in <module>
    from cricket.app import main as cricket_main
  File "/Users/yinon.horev/code/csr_vnv/.venv/lib/python3.7/site-packages/cricket/app.py", line 9, in <module>
    from cricket.view import Cricket
  File "/Users/yinon.horev/code/csr_vnv/.venv/lib/python3.7/site-packages/cricket/view.py", line 14, in <module>
    from toga.font import BOLD, SANS_SERIF
ModuleNotFoundError: No module named 'toga.font'
`
 After a typo fix it worked on MAC OS X Catalina (10.15.4) and Windows 10 (Python 3.7.3)