### PR TITLE
Standardize pypa/gh-action-pypi-publish pin formatting

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,4 +23,4 @@ jobs:
           target: dist/
 
       - name: Publish release to production PyPI
-        uses: pypa/gh-action-pypi-publish@ba38be9e461d3875417946c167d0b5f3d385a247 # v1.14.1
+        uses: pypa/gh-action-pypi-publish@ba38be9e461d3875417946c167d0b5f3d385a247  # v1.14.1

--- a/changes/106.misc.md
+++ b/changes/106.misc.md
@@ -1,0 +1,1 @@
+Standardized formatting of the pypa/gh-action-pypi-publish action pin.


### PR DESCRIPTION
Standardizes formatting of the `pypa/gh-action-pypi-publish` action pin (`ba38be9e461d3875417946c167d0b5f3d385a247`, i.e. `v1.14.1`) to match the convention used elsewhere in the workflow files.

## PR Checklist:
- [x] I will abide by the BeeWare Code of Conduct
- [x] I have read and have followed the **CONTRIBUTING.md** file
- [x] This PR was generated or assisted using an AI tool
Assisted-by: Claude Sonnet 5
